### PR TITLE
feat(build): add Premake workspace and CompilerCore project

### DIFF
--- a/Compiler/Premake5.lua
+++ b/Compiler/Premake5.lua
@@ -1,0 +1,28 @@
+include "Dependencies.lua"
+
+project "CompilerCore"
+	kind "StaticLib"	
+
+	targetdir ("%{wks.location}/bin/" .. outputdir .. "/%{prj.name}")
+	objdir ("%{wks.location}/bin-int/" .. outputdir .. "/%{prj.name}")
+
+	files
+	{
+		"%{SourceDir.Core}" .. "/**.c",
+		"%{SourceDir.Common}" .. "/**.c",
+		"%{SourceDir.Utils}" .. "/**.c",
+
+		"%{SourceDir.Core}" .. "/**.h",
+		"%{SourceDir.Common}" .. "/**.h",
+		"%{SourceDir.Utils}" .. "/**.h",
+
+		"%{IncludeDir.Core}" .. "/**.h",
+		"%{IncludeDir.Common}" .. "/**.h",
+		"%{IncludeDir.Utils}" .. "/**.h"
+	}
+
+	includedirs {
+		"%{IncludeDir.Core}",
+		"%{IncludeDir.Common}",
+		"%{IncludeDir.Utils}"
+	}

--- a/Dependencies.lua
+++ b/Dependencies.lua
@@ -1,0 +1,18 @@
+
+-- Compiler engine dependecies
+
+IncludeDir = {}
+IncludeDir["Core"] = "%{wks.location}/Compiler/Core/include"
+IncludeDir["Common"] = "%{wks.location}/Compiler/Common/include"
+IncludeDir["Utils"] = "%{wks.location}/Compiler/Utils/include"
+
+SourceDir = {}
+SourceDir["Core"] = "%{wks.location}/Compiler/Core/src"
+SourceDir["Common"] = "%{wks.location}/Compiler/Common/src"
+SourceDir["Utils"] = "%{wks.location}/Compiler/Utils/src"
+
+
+LibraryDir = {}
+
+
+Library = {}

--- a/premake5.lua
+++ b/premake5.lua
@@ -1,0 +1,25 @@
+include "Dependencies.lua"
+
+workspace "Compile Driver"
+	architecture "x86_64"
+	--startproject "Application"
+
+	toolset "clang"
+
+	configurations
+	{
+		"Debug",
+		"Release",
+		"Dist"
+	}
+
+	flags
+	{
+		"MultiProcessorCompile"
+	}
+
+outputdir = "%{wks.location}/bin/%{cfg.buildcfg}-%{cfg.system}-%{cfg.architecture}"
+
+group "Core"
+	include "Compiler"
+group ""


### PR DESCRIPTION
- Add premake.lua to define theCompile Driver" workspace with x86_64 Clang toolset, Debug/Release/Dist configurations, and parallel build flags
- Add Dependencies.lua to centralize include and source directory mappings for Core, Common, and Utils modules
- Add Compiler/Premake5.lua to declare the CompilerCore static library target, set output and object directories, and register source/header files (globbed under Core, Common, Utils)
- Populate include paths for CompilerCore from the centralized Dependencies.lua mappings